### PR TITLE
Python3 adaptation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,9 @@ clickhouse_docker_published_ports:
   - "9000"
   - "9009"
 clickhouse_docker_exposed_ports:
-  - 8123
-  - 9000
-  - 9009
+  - "8123"
+  - "9000"
+  - "9009"
 clickhouse_docker_log_driver: json-file
 clickhouse_docker_log_options:
 

--- a/templates/macros.xml.j2
+++ b/templates/macros.xml.j2
@@ -5,7 +5,7 @@
 {% if clickhouse_docker_macros is defined and clickhouse_docker_macros != None %}
 <macros replace="1">
 
-    {% for key, value in clickhouse_docker_macros.iteritems() %}
+    {% for key, value in clickhouse_docker_macros.items() %}
     <{{ key }}>{{ value }}</{{ key }}>
     {% endfor %}
 

--- a/templates/remote_servers.xml.j2
+++ b/templates/remote_servers.xml.j2
@@ -10,11 +10,11 @@
 
             {% for shard in clickhouse_docker_remote_servers[cluster] %}
                 <shard>
-                {% for key, value in shard['shard'].iteritems() %}
+                {% for key, value in shard['shard'].items() %}
                     {% if key == 'replica' %}
                     {% for replica in shard['shard']['replica'] %}
                     <replica>
-                        {% for r_key, r_value in replica.iteritems() %}
+                        {% for r_key, r_value in replica.items() %}
                         <{{ r_key }}>{{ r_value }}</{{ r_key }}>
                         {% endfor %}
                     </replica>


### PR DESCRIPTION
These changes fix the bug:
```
TASK [searchmetrics.ansible-role-docker-clickhouse : Create ClickHouse remote server config] ***************************************************************************************************************
fatal: [ch1.gillbus.com]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}
```